### PR TITLE
fix: Make license information for 3rd party modules deterministic

### DIFF
--- a/banner-template.txt
+++ b/banner-template.txt
@@ -1,7 +1,3 @@
-@name <%= pkg.name %>
-@license <%= pkg.license %>
-@version <%= pkg.version %> (generated <%= moment().format('YYYY-MM-DD') %>)
-
 Included dependencies:<% dependencies.sort((a,b) => a.name.localeCompare(b.name)) %>
 <% _.forEach(dependencies.sort(), function (dependency) { %>
 <%= dependency.name %>

--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -18,7 +18,7 @@ export const appName = process.env.npm_package_name
 export const appVersion = process.env.npm_package_version
 export const appNameSanitized = appName.replace(/[/\\]/, '-')
 
-export interface AppOptions extends Omit<BaseOptions, 'nodePolyfills'> {
+export interface AppOptions extends BaseOptions {
 	/**
 	 * Whether to empty the output directory (`js/`)
 	 * @default true
@@ -32,6 +32,14 @@ export interface AppOptions extends Omit<BaseOptions, 'nodePolyfills'> {
 	 * @default {protocolImports: true}
 	 */
 	nodePolyfills?: boolean | NodePolyfillsOptions
+
+	/**
+	 * Location of license summary file of third party dependencies
+	 * Pass `false` to disable generating a license file.
+	 *
+	 * @default 'js/vendor.LICENSE.txt'
+	 */
+	thirdPartyLicense?: false | string
 }
 
 /**
@@ -48,7 +56,14 @@ export interface AppOptions extends Omit<BaseOptions, 'nodePolyfills'> {
  */
 export const createAppConfig = (entries: { [entryAlias: string]: string }, options: AppOptions = {}): UserConfigFn => {
 	// Add default options
-	options = { config: {}, nodePolyfills: { protocolImports: true }, ...options }
+	options = {
+		config: {},
+		nodePolyfills: {
+			protocolImports: true,
+		},
+		thirdPartyLicense: options.thirdPartyLicense === undefined ? 'js/vendor.LICENSE.txt' : options.thirdPartyLicense,
+		...options,
+	}
 
 	return createBaseConfig({
 		...options,


### PR DESCRIPTION
Currently the license information is written as a comment with the files, which is non deterministic resulting in node tests failures for e.g. logreader CI.

This way we output a LICENSE.txt containing all required license information similar to how it is currently done by using webpack.

:heavy_plus_sign: Reduced JS bundle while still providing the licenses.