### PR TITLE
fix(lib): Include hash in assets name

### DIFF
--- a/lib/libConfig.ts
+++ b/lib/libConfig.ts
@@ -92,7 +92,7 @@ export const createLibConfig = (entries: { [entryAlias: string]: string }, optio
 				if (!options.inlineCSS && /css/i.test(extType)) {
 					return '[name].css'
 				}
-				return 'assets/[name][extname]'
+				return 'assets/[name]-[hash][extname]'
 			}
 
 			// Manually define output options for file extensions


### PR DESCRIPTION
When using css inlining and multiple output formats (e.g. esm and cjs) the assets order is not deterministic. This causes issues if the assets are named the same, e.g. if you have multiple "index" entry points the assets will be called index1, index2... So when not using hashes the last output format might override the assets with a changed order, causing the previous output formats to be invalid.