### PR TITLE
fix: Remove `define` of `process.env` from base config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Ferdinand Thiessen <opensource@fthiessen.de>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+__fixtures__/*/js
 coverage/
 dist/
 node_modules/
+js/

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,6 +3,6 @@ Upstream-Name: nextcloud-vite-config
 Upstream-Contact: Ferdinand Thiessen <rpm@fthiessen.de>
 Source: https://github.com/susnux/nextcloud-vite-config
 
-Files: package-lock.json package.json tsconfig.json .gitignore banner-template.txt README.md CHANGELOG.md
+Files: package-lock.json package.json tsconfig.json banner-template.txt README.md CHANGELOG.md __tests__/__snapshots__/*
 Copyright: Ferdinand Thiessen <rpm@fthiessen.de>
 License: AGPL-3.0-or-later

--- a/__fixtures__/app_process_env/main.js
+++ b/__fixtures__/app_process_env/main.js
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+window.my_timezone = process.env.TZ

--- a/__tests__/__snapshots__/appconfig.spec.ts.snap
+++ b/__tests__/__snapshots__/appconfig.spec.ts.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`app config > replaces process.env 1`] = `
+"/*! third party licenses: js/vendor.LICENSE.txt */
+window.my_timezone={}.TZ;
+"
+`;

--- a/__tests__/appconfig.spec.ts
+++ b/__tests__/appconfig.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { build } from 'vite'
+// ok as this is just for tests
+// eslint-disable-next-line n/no-extraneous-import
+import type { RollupOutput, OutputChunk } from 'rollup'
+import { describe, it, expect } from 'vitest'
+import { createAppConfig } from '../lib/appConfig'
+import { fileURLToPath } from 'url'
+import { resolve } from 'path'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+
+describe('app config', () => {
+	it('replaces process.env', async () => {
+		const root = resolve(__dirname, '../__fixtures__/app_process_env')
+
+		const resolved = await createAppConfig({
+			main: resolve(root, 'main.js'),
+		})({ command: 'build', mode: 'production' })
+
+		const result = await build({
+			...resolved,
+			root,
+		})
+		const { output } = result as RollupOutput
+		const code = (output[0] as OutputChunk).code
+		expect(code.includes('process.env')).toBe(false)
+		expect(code).toMatchSnapshot()
+	})
+})

--- a/lib/baseConfig.ts
+++ b/lib/baseConfig.ts
@@ -129,15 +129,6 @@ export function createBaseConfig(options: BaseOptions = {}): UserConfigFn {
 				// Remove unneeded whitespace
 				options?.minify ? minifyPlugin() : undefined,
 			],
-			define: {
-				// process env replacement (keep order of this rules)
-				'globalThis.process.env.NODE_ENV': JSON.stringify(mode),
-				'globalThis.process.env.': '({}).',
-				'global.process.env.NODE_ENV': JSON.stringify(mode),
-				'global.process.env.': '({}).',
-				'process.env.NODE_ENV': JSON.stringify(mode),
-				'process.env.': '({}).',
-			},
 			esbuild: {
 				legalComments: 'inline',
 				target: browserslistToEsbuild(),


### PR DESCRIPTION
Removing `process.env` is only required for apps, as we now build apps not in lib mode it is removed automatically by vite.

Fixes testing issues when using vitest.