### PR TITLE
fix(libConfig): import default in CJS build

### DIFF
--- a/lib/libConfig.ts
+++ b/lib/libConfig.ts
@@ -102,6 +102,7 @@ export const createLibConfig = (entries: { [entryAlias: string]: string }, optio
 				const extension = format === 'es' ? 'mjs' : (format === 'cjs' ? 'cjs' : `${format}.js`)
 				return {
 					format,
+					interop: 'auto', // Add __esModule for CJS externals imports to fix interop issues in tools like Babel/TS
 					hoistTransitiveImports: false, // For libraries this might otherwise introduce side effects
 					preserveModules: false,
 					assetFileNames,


### PR DESCRIPTION
## How to test

1. Use https://github.com/nextcloud/server/pull/40692 with the latest `@nextcloud/vue`
2. Run `npm test` (or better just `npx jest CalDavSetting` for a single test)
3. See `[Vue warn]: Failed to mount component: template or render function not defined`

## A problem

By default, 

> Rollup assumes that the required value should be treated as the default export of the imported module, just like when importing CommonJS from an ES module context in NodeJS. This is different from the default behavior in many tools like Babel or TS.

As a result, when a CJS lib built with this config is used with such tooling, external dependencies are imported as an object with a default property.
```js
// Inside NcComponent.cjs
const icon = require('vue-material-design-icons/Icon.vue)

// Imports as

{
  default: {
    name: 'Icon',
    render: () => {},
  }
}

// Instead of

{
  name: 'Icon',
  render: () => {},
}
```

## Proposal

`interop: auto` adds a hack with `__esModule` to help tools interpret it.

## Alternative 

Formally `__esModule` is a hack. Supported by all the tolling but still.

`interop: compat` also works checking how the module was imported

See: https://rollupjs.org/configuration-options/#output-interop

## P.S.

I'm not sure it fixes all the issues with the new CJS built. Checking...