### PR TITLE
fix: Do not set vue's `comments` setting for dev builds

### DIFF
--- a/lib/baseConfig.ts
+++ b/lib/baseConfig.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { CoreJSPluginOptions } from 'rollup-plugin-corejs'
+import type { UserConfigExport, UserConfigFn, Rollup } from 'vite'
+
 import { readFileSync } from 'node:fs'
-import { type CoreJSPluginOptions, corejsPlugin } from 'rollup-plugin-corejs'
+import { corejsPlugin } from 'rollup-plugin-corejs'
 import { minify as minifyPlugin } from 'rollup-plugin-esbuild-minify/lib/index.js'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
-import { defineConfig, mergeConfig, type UserConfigExport, type UserConfigFn, type Rollup } from 'vite'
+import { defineConfig, mergeConfig } from 'vite'
 import { RemoveEnsureWatchPlugin } from './plugins/RemoveEnsureWatch.js'
 
 import replace from '@rollup/plugin-replace'
@@ -126,11 +129,6 @@ export function createBaseConfig(options: BaseOptions = {}): UserConfigFn {
 					isProduction: !isDev,
 					style: {
 						trim: true,
-					},
-					template: {
-						compilerOptions: {
-							comments: isDev,
-						},
 					},
 				}),
 				// Add custom plugins


### PR DESCRIPTION
This might lead to unexpected behavior, for example this will break some `@nextcloud/vue` components like `NcActionCheckbox`.
Because then if you use translation comments the text will be broken.

```html
<NcActionCheckbox>
  <!-- TRANSLATORS: Some context -->
  {{ t('foo', 'bar') }}
</NcActionCheckbox>
```

This will not lead to a checkbox with the text *TRANSLATORS: Some context* as the first VNode is the comment. This is not expected behavior. Users should set this config flag manually if needed.