### PR TITLE
chore: Prepare patch release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v1.1.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/tree/v1.1.1) (2023-12-19)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.1.0...v1.1.1)
+
+### :bug: Fixed bugs
+* fix(typing): fix typo in typing by [\#69](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/69) \([ShGKme](https://github.com/ShGKme)\)
+* fix: typo in readme by [\#83](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/83) \([raimund-schluessler](https://github.com/raimund-schluessler)\)
+* fix: Do not set vue's `comments` setting for dev builds by [\#84](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/84) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* Updated dependencies
+
 ## [v1.1.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/tree/v1.1.0) (2023-10-20)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.0.1...v1.1.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"license": "AGPL-3.0-or-later",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## [v1.1.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/tree/v1.1.1) (2023-12-19)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.1.0...v1.1.1)

### :bug: Fixed bugs
* fix(typing): fix typo in typing by [\#69](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/69) \([ShGKme](https://github.com/ShGKme)\)
* fix: typo in readme by [\#83](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/83) \([raimund-schluessler](https://github.com/raimund-schluessler)\)
* fix: Do not set vue's `comments` setting for dev builds by [\#84](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/84) \([susnux](https://github.com/susnux)\)

### Changed
* Updated dependencies