### PR TITLE
fix: Move fonts to `css/fonts` and fix css path resolving

### DIFF
--- a/__tests__/appconfig.spec.ts
+++ b/__tests__/appconfig.spec.ts
@@ -56,6 +56,18 @@ describe('app config', () => {
 		expect(assetFileNames({ name: 'some.ico' })).toBe('img/[name][extname]')
 	})
 
+	it('moves fonts to css/fonts', async () => {
+		const resolved = await createConfig('build', 'development')
+
+		const output = resolved.build.rollupOptions.output as OutputOptions
+		expect(typeof output?.assetFileNames).toBe('function')
+		const assetFileNames = output?.assetFileNames as ((chunkInfo: unknown) => string)
+		expect(assetFileNames({ name: 'some.woff' })).toBe('css/fonts/[name][extname]')
+		expect(assetFileNames({ name: 'some.woff2' })).toBe('css/fonts/[name][extname]')
+		expect(assetFileNames({ name: 'some.otf' })).toBe('css/fonts/[name][extname]')
+		expect(assetFileNames({ name: 'some.ttf' })).toBe('css/fonts/[name][extname]')
+	})
+
 	it('allow custom asset names', async () => {
 		const resolved = await createConfig('build', 'development', { assetFileNames: (({ name }) => name === 'main.css' ? 'css/app-styles.css' : undefined) as never })
 


### PR DESCRIPTION
When you import e.g. fonts in your scss like `url(some/font.woff)` the woff needs to be placed correctly, and especially the path needs to be set.

CSS does not allow dynamic URLs so we can not use our `OC.filepath` function but need to return a relative path to the CSS file that loaded the woff.