### PR TITLE
fix(base): Correctly pass minify configuration to vite

### DIFF
--- a/__tests__/baseconfig.spec.ts
+++ b/__tests__/baseconfig.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { BaseOptions, createBaseConfig } from '../lib/baseConfig'
+import { resolveConfig } from 'vite'
+
+const createConfig = async (
+	command: 'build' | 'serve' = 'build',
+	mode: 'development' | 'production' = 'production',
+	options?: BaseOptions,
+) =>
+	await resolveConfig(
+		await createBaseConfig(
+			options,
+		)({ command, mode, isSsrBuild: false }),
+		command,
+	)
+
+describe('baseconfig', () => {
+	it('Correctly set minify option to false', async () => {
+		const config = await createConfig('build', 'production', { minify: false })
+		expect(config.build.minify).toBe(false)
+		expect(config.plugins.find(({ name }) => name === 'esbuild-minify')).toBeUndefined()
+	})
+
+	it('Correctly set minify option to true', async () => {
+		const config = await createConfig('build', 'production', { minify: true })
+		expect(config.build.minify).toBe('esbuild')
+		expect(config.plugins.findIndex(({ name }) => name === 'esbuild-minify')).toBeGreaterThanOrEqual(0)
+	})
+})

--- a/__tests__/libconfig.spec.ts
+++ b/__tests__/libconfig.spec.ts
@@ -11,7 +11,7 @@ import { LibraryOptions, createLibConfig } from '../lib/libConfig'
 describe('library config', () => {
 	describe('workaround vite#14515 minify bug', () => {
 		it('minifies using esbuild by default', async () => {
-			const resolved = await createConfig('build')
+			const resolved = await createConfig('build', 'production', { minify: true })
 
 			// there is no minify plugin
 			expect(resolved.plugins.filter((plugin) => plugin.name === 'esbuild-minify').length).toBe(0)
@@ -72,7 +72,17 @@ describe('library config', () => {
 		})
 	})
 
-	const createConfig = async (command: 'build' | 'serve' = 'build', mode: 'development' | 'production' = 'production', options?: LibraryOptions) => await resolveConfig(await createLibConfig({
-		main: 'src/main.js',
-	}, options)({ command, mode, isSsrBuild: false }), command)
+	const createConfig = async (
+		command: 'build' | 'serve' = 'build',
+		mode: 'development' | 'production' = 'production',
+		options?: LibraryOptions,
+	) => {
+		return await resolveConfig(
+			await createLibConfig(
+				{
+					main: 'src/main.js',
+				},
+				options,
+			)({ command, mode, isSsrBuild: false }), command)
+	}
 })

--- a/lib/baseConfig.ts
+++ b/lib/baseConfig.ts
@@ -142,6 +142,7 @@ export function createBaseConfig(options: BaseOptions = {}): UserConfigFn {
 				banner: options.thirdPartyLicense ? `/*! third party licenses: ${options.thirdPartyLicense} */` : undefined,
 			},
 			build: {
+				minify: !!options.minify,
 				cssTarget: browserslistToEsbuild(),
 				sourcemap: isDev || 'hidden',
 				target: browserslistToEsbuild(),

--- a/lib/libConfig.ts
+++ b/lib/libConfig.ts
@@ -18,6 +18,12 @@ type OutputOptions = BuildOptions['rollupOptions']['output']
 
 export interface LibraryOptions extends BaseOptions {
 	/**
+	 * Whether to minify the output
+	 * @default false For libraries the code is not minified by default for better DX. Usually it is not needed: a library will be minified as a part of an app bundling.
+	 */
+	minify?: boolean
+
+	/**
 	 * Options for the rollup node externals plugin
 	 *
 	 * By default all `dependencies` and `peerDependencies` are marked as external.
@@ -52,7 +58,13 @@ export interface LibraryOptions extends BaseOptions {
  */
 export const createLibConfig = (entries: { [entryAlias: string]: string }, options: LibraryOptions = {}): UserConfigFn => {
 	// Add default values for options
-	options = { config: {}, nodeExternalsOptions: {}, libraryFormats: ['es'], ...options }
+	options = {
+		config: {},
+		minify: false,
+		nodeExternalsOptions: {},
+		libraryFormats: ['es'],
+		...options,
+	}
 
 	const node = nodeExternals({
 		builtins: true, // Mark all node core modules, like `path` as external
@@ -137,7 +149,7 @@ export const createLibConfig = (entries: { [entryAlias: string]: string }, optio
 						formats: options.libraryFormats,
 					},
 					// workaround, see above
-					minify: options.minify ?? env.mode === 'production' ? 'esbuild' : false,
+					minify: (options.minify ?? env.mode === 'production') ? 'esbuild' : false,
 					cssCodeSplit: true,
 					outDir: 'dist',
 					rollupOptions: {


### PR DESCRIPTION
If minify is disabled we need to not only not include the esbuild plugin but also set the option for vite to disable it.