### PR TITLE
fix: explicitly use window.OC global in app config

### DIFF
--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -127,7 +127,7 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 						}
 						return {
 							// already contains the "js/" prefix as it is our output file configuration
-							runtime: `OC.filePath('${appName}', '', '${filename}')`,
+							runtime: `window.OC.filePath('${appName}', '', '${filename}')`,
 						}
 					},
 				},


### PR DESCRIPTION
(Production) bundles generated by vite break if the optimizer generates a `const` declaration that randomly has the name `OC`.

`Uncaught ReferenceError: can't access lexical declaration 'OC' before initialization`

> A lexical variable was accessed before it was initialized. This happens within any scope (global, module, function, or block) when variables declared with [let](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) or [const](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) are accessed before the place where they are declared has been executed.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init#what_went_wrong