### PR TITLE
feat(app-config): Add option to override the app name

### DIFF
--- a/__tests__/appconfig.spec.ts
+++ b/__tests__/appconfig.spec.ts
@@ -17,6 +17,16 @@ import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 describe('app config', () => {
+	it('adds global appName variable', async () => {
+		const resolved = await createConfig('build', 'development')
+		expect([resolved.build.rollupOptions.output!].flat()[0].intro).toMatch(/appName = "@nextcloud\/vite-config"/)
+	})
+
+	it('adds global appName variable with override', async () => {
+		const resolved = await createConfig('build', 'development', { appName: 'spreed' })
+		expect([resolved.build.rollupOptions.output!].flat()[0].intro).toMatch(/appName = "spreed"/)
+	})
+
 	it('replaces process.env', async () => {
 		const root = resolve(__dirname, '../__fixtures__/app_process_env')
 


### PR DESCRIPTION
Some apps use a different name in package.json than the real app ID is. But we need the app ID, so add an option to override it.