### PR TITLE
Allow to specify an output prefix and load app id from appinfo

### DIFF
--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -29,6 +29,12 @@ export interface AppOptions extends Omit<BaseOptions, 'inlineCSS'> {
 	appName?: string
 
 	/**
+	 * Prefix to use for assets and chunks
+	 * @default '{appName}-'
+	 */
+	assetsPrefix?: string
+
+	/**
 	 * Inject all styles inside the javascript bundle instead of emitting a .css file
 	 * @default false
 	 */
@@ -85,6 +91,8 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 		...(options as BaseOptions),
 		config: async (env) => {
 			console.info(`Building ${options.appName} for ${env.mode}`)
+
+			const assetsPrefix = (options.assetsPrefix ?? `${options.appName}-`).replace(/[/\\]/, '-')
 
 			// This config is used to extend or override our base config
 			// Make sure we get a user config and not a promise or a user config function
@@ -162,17 +170,17 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 								if (/png|jpe?g|svg|gif|tiff|bmp|ico/i.test(extType)) {
 									return 'img/[name][extname]'
 								} else if (/css/i.test(extType)) {
-									return `css/${sanitizeAppName(options.appName)}-[name].css`
+									return `css/${assetsPrefix}[name].css`
 								} else if (/woff2?|ttf|otf/i.test(extType)) {
 									return 'css/fonts/[name][extname]'
 								}
 								return 'dist/[name]-[hash][extname]'
 							},
 							entryFileNames: () => {
-								return `js/${sanitizeAppName(options.appName)}-[name].mjs`
+								return `js/${assetsPrefix}[name].mjs`
 							},
 							chunkFileNames: () => {
-								return 'js/[name]-[hash].mjs'
+								return 'js/[name].chunk.mjs'
 							},
 							manualChunks: {
 								...(options?.coreJS ? { polyfill: ['core-js'] } : {}),

--- a/lib/utils/appinfo.ts
+++ b/lib/utils/appinfo.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { lstatSync } from 'node:fs'
+import { join, resolve, sep } from 'node:path'
+
+/**
+ * Check if a given path exists and is a directory
+ *
+ * @param {string} filePath The path
+ * @return {boolean}
+ */
+function isDirectory(filePath: string): boolean {
+	const stats = lstatSync(filePath, { throwIfNoEntry: false })
+	return stats !== undefined && stats.isDirectory()
+}
+
+/**
+ * Check if a given path exists and is a directory
+ *
+ * @param {string} filePath The path
+ * @return {boolean}
+ */
+function isFile(filePath: string): boolean {
+	const stats = lstatSync(filePath, { throwIfNoEntry: false })
+	return stats !== undefined && stats.isFile()
+}
+
+/**
+ * Find the path of nearest `appinfo/info.xml` relative to given path
+ *
+ * @param {string} currentPath The path to check for appinfo
+ * @return {string|undefined} Either the full path including the `info.xml` part or `undefined` if no found
+ */
+export function findAppinfo(currentPath: string): string | null {
+	while (currentPath && currentPath !== sep) {
+		const appinfoPath = join(currentPath, 'appinfo')
+		if (isDirectory(appinfoPath) && isFile(join(appinfoPath, 'info.xml'))) {
+			return join(appinfoPath, 'info.xml')
+		}
+		currentPath = resolve(currentPath, '..')
+	}
+	return undefined
+}


### PR DESCRIPTION
1. Allow to set a custom prefix for assets instead of forcing `appName-`
2. Load app id from appinfo if possible