### PR TITLE
chore: Prepare v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.3.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/tree/v1.3.0) (2024-06-21)
+### Added
+* feat(app-config): Add option to override the app name [\#206](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/206) \([susnux](https://github.com/susnux)\)
+* Allow to specify an output prefix and load app id from appinfo [\#209](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/209) \([susnux](https://github.com/susnux)\)
+* feat: Add `CSSEntryPointsPlugin` to fix vite for creating one CSS entry per JS entry point [\#210](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/210) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* chore(deps-dev): Bump vite from 5.2.13 to 5.3.1
+
 ## [v1.2.5](https://github.com/nextcloud-libraries/nextcloud-vite-config/tree/v1.2.5) (2024-06-14)
 ### Fixed
 * fix: explicitly use window.OC global in app config [\#197](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/197) \([st3iny](https://github.com/st3iny)\)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.2.5",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "1.2.5",
+			"version": "1.3.0",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^5.0.7",
@@ -23,7 +23,7 @@
 			},
 			"devDependencies": {
 				"@nextcloud/eslint-config": "^8.4.1",
-				"@types/node": "^20.14.2",
+				"@types/node": "^20.14.7",
 				"@vitest/coverage-v8": "^1.6.0",
 				"typedoc": "^0.25.13",
 				"typescript": "^5.4.5",
@@ -1495,9 +1495,9 @@
 			"peer": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.14.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-			"integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+			"version": "20.14.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.7.tgz",
+			"integrity": "sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==",
 			"devOptional": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -2342,12 +2342,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"peer": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -3964,9 +3964,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"peer": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"license": "AGPL-3.0-or-later",
-	"version": "1.2.5",
+	"version": "1.3.0",
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"@nextcloud/eslint-config": "^8.4.1",
-		"@types/node": "^20.14.2",
+		"@types/node": "^20.14.7",
 		"@vitest/coverage-v8": "^1.6.0",
 		"typedoc": "^0.25.13",
 		"typescript": "^5.4.5",


### PR DESCRIPTION
## [v1.3.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/tree/v1.3.0) (2024-06-21)
### Added
* feat(app-config): Add option to override the app name [\#206](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/206) \([susnux](https://github.com/susnux)\)
* Allow to specify an output prefix and load app id from appinfo [\#209](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/209) \([susnux](https://github.com/susnux)\)
* feat: Add `CSSEntryPointsPlugin` to fix vite for creating one CSS entry per JS entry point [\#210](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/210) \([susnux](https://github.com/susnux)\)

### Changed
* chore(deps-dev): Bump vite from 5.2.13 to 5.3.1