### PR TITLE
feat(EmptyJSDirPlugin): Allow to specify other directories to clear

### DIFF
--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -14,7 +14,7 @@ import { mergeConfig } from 'vite'
 import { createBaseConfig } from './baseConfig.js'
 import { findAppinfo } from './utils/appinfo.js'
 
-import EmptyJSDirPlugin from './plugins/EmptyJSDir.js'
+import EmptyJSDirPlugin, { EmptyJSDirPluginOptions } from './plugins/EmptyJSDir.js'
 import replace from '@rollup/plugin-replace'
 import injectCSSPlugin from 'vite-plugin-css-injected-by-js'
 import { CSSEntryPointsPlugin } from './plugins/CSSEntryPoints.js'
@@ -49,10 +49,12 @@ export interface AppOptions extends Omit<BaseOptions, 'inlineCSS'> {
 	createEmptyCSSEntryPoints?: boolean
 
 	/**
-	 * Whether to empty the output directory (`js/`)
+	 * Whether to empty the 'js' directory
+	 * Pass `false` to disable clearing the directory,
+	 * it is also possible to pass options to the plugin.
 	 * @default true
 	 */
-	emptyOutputDirectory?: boolean
+	emptyOutputDirectory?: boolean | EmptyJSDirPluginOptions
 
 	/**
 	 * Inject polyfills for node packages
@@ -146,7 +148,13 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 			// defaults to true so only not adding if explicitly set to false
 			if (options?.emptyOutputDirectory !== false) {
 				// Ensure `js/` is empty as we can not use the build in option (see below)
-				plugins.push(EmptyJSDirPlugin())
+				plugins.push(
+					EmptyJSDirPlugin(
+						typeof options.emptyOutputDirectory === 'object'
+							? options.emptyOutputDirectory
+							: undefined
+					),
+				)
 			}
 
 			// When building in serve mode (e.g. unit tests with vite) the intro option below will be ignored, so we must replace that values

--- a/lib/plugins/EmptyJSDir.ts
+++ b/lib/plugins/EmptyJSDir.ts
@@ -9,18 +9,34 @@ import type { Plugin } from 'vite'
 import { existsSync, rmSync } from 'node:fs'
 import * as path from 'node:path'
 
+export interface EmptyJSDirPluginOptions {
+	/**
+	 * Additional directories to clear (e.g. 'css')
+	 * @default []
+	 */
+	additionalDirectories?: string[]
+}
+
 /**
  * Vite plugin to clear the `js/` directory before emitting files
+ *
+ * @param options Options to pass to the plugin
  */
-const EmptyJSDirPlugin = () => {
+function EmptyJSDirPlugin(options?: EmptyJSDirPluginOptions) {
 	let emptyJSDir = false
 
 	return {
 		name: 'nextcloud-empty-js',
 		generateBundle() {
 			if (emptyJSDir !== true) {
-				if (existsSync(path.resolve('js/'))) {
-					rmSync(path.resolve('js/'), { recursive: true })
+				const dirs = [
+					...(options?.additionalDirectories ?? []),
+					'js',
+				]
+				for (const dir of dirs) {
+					if (existsSync(path.resolve(dir))) {
+						rmSync(path.resolve(dir), { recursive: true })
+					}
 				}
 				emptyJSDir = true
 			}


### PR DESCRIPTION
This is sometimes handy if you extract the CSS then also the `css/` directory should be cleared.