### PR TITLE
fix: Revert chunkFileNames to include hash

### DIFF
--- a/__tests__/css-entry-points.spec.ts
+++ b/__tests__/css-entry-points.spec.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+// eslint-disable-next-line n/no-extraneous-import
 import type { RollupOutput, OutputAsset } from 'rollup'
+
 import { build } from 'vite'
 import { describe, it, expect } from 'vitest'
 import { CSSEntryPointsPlugin } from '../lib/plugins/CSSEntryPoints'

--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -221,7 +221,7 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 								return `js/${assetsPrefix}[name].mjs`
 							},
 							chunkFileNames: () => {
-								return 'js/[name].chunk.mjs'
+								return 'js/chunks/[name]-[hash].mjs'
 							},
 							manualChunks: {
 								...(options?.coreJS ? { polyfill: ['core-js'] } : {}),

--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -152,7 +152,7 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 					EmptyJSDirPlugin(
 						typeof options.emptyOutputDirectory === 'object'
 							? options.emptyOutputDirectory
-							: undefined
+							: undefined,
 					),
 				)
 			}
@@ -211,6 +211,10 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 								if (/png|jpe?g|svg|gif|tiff|bmp|ico/i.test(extType)) {
 									return 'img/[name][extname]'
 								} else if (/css/i.test(extType)) {
+									if (userConfig.build?.cssCodeSplit !== false) {
+										// we need hashed css name for css chunks as a cache buster
+										return 'css/[name]-[hash].css'
+									}
 									return `css/${assetsPrefix}[name].css`
 								} else if (/woff2?|ttf|otf/i.test(extType)) {
 									return 'css/fonts/[name][extname]'
@@ -221,7 +225,7 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 								return `js/${assetsPrefix}[name].mjs`
 							},
 							chunkFileNames: () => {
-								return 'js/chunks/[name]-[hash].mjs'
+								return 'js/[name]-[hash].chunk.mjs'
 							},
 							manualChunks: {
 								...(options?.coreJS ? { polyfill: ['core-js'] } : {}),


### PR DESCRIPTION
Otherwise the browser cache is not refetching updated files.

I noticed after the upgrade on our instance today that the files app was having weired styles, only a force refresh helped. Not sure this has been exactly this issue, but as I talked with someone before (likely @susnux) I thought I'd open that PR.