### PR TITLE
fix(REUSELicensesPlugin): remove duplicates in license files

### DIFF
--- a/lib/plugins/REUSELicensesPlugin.ts
+++ b/lib/plugins/REUSELicensesPlugin.ts
@@ -204,13 +204,15 @@ export function REUSELicensesPlugin(options: REUSELicensesPluginOptions = {}): P
 					}
 				}
 
-				const packages = new Set((
-					await Promise.all(
-						[...modules.values()]
-							.map(sanitizeName)
-							.map(findPackage),
-					)).filter(Boolean),
-				)
+				// Get all package license data of the modules
+				const allPackages = (await Promise.all(
+					[...modules.values()]
+						.map(sanitizeName)
+						.map(findPackage),
+				)).filter(Boolean)
+
+				// Remove duplicates by serialized package license data
+				const packages = [...new Map(allPackages.map((item) => [JSON.stringify(item), item])).values()]
 
 				const sortedPackages = [...packages].sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version, undefined, { numeric: true }))
 				const authors = new Set(sortedPackages.map(({ author }) => author))


### PR DESCRIPTION
- `new Set()` of object array doesn't remove duplicates, because object with the same values still have different references
- Using `Map` with serialized key to remove duplicates