### PR TITLE
fix(appConfig): move chunks to `chunks` sub directory

### DIFF
--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -240,7 +240,7 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 								return `js/${assetsPrefix}[name].mjs`
 							},
 							chunkFileNames: () => {
-								return 'js/[name]-[hash].chunk.mjs'
+								return 'js/chunks/[name]-[hash].chunk.mjs'
 							},
 							manualChunks: {
 								...(options?.coreJS ? { polyfill: ['core-js'] } : {}),

--- a/lib/plugins/CSSEntryPoints.ts
+++ b/lib/plugins/CSSEntryPoints.ts
@@ -44,7 +44,10 @@ export function CSSEntryPointsPlugin(options?: CSSEntryPointsPluginOptions) {
 					// If the original assets name option is a function we need to call it otherwise just use the template string
 					const name = typeof config === 'function' ? config(info) : config
 					// Only handle CSS files not extracted by this plugin
-					if (info.name.endsWith('.css') && !String(info.source).startsWith('/* extracted by css-entry-points-plugin */')) {
+					if (info.name.endsWith('.css')
+						&& !String(info.source).startsWith('/* extracted by css-entry-points-plugin */')
+						&& !info.name.endsWith('extracted-by-css-entry-points-plugin.css')
+					) {
 						// The new name should have the same path but instead of the .css extension it is .chunk.css
 						return name.replace(/(.css|.\[ext\]|\[extname\])$/, '.chunk.css')
 					}
@@ -112,7 +115,7 @@ export function CSSEntryPointsPlugin(options?: CSSEntryPointsPluginOptions) {
 				const path = dirname(
 					typeof options.assetFileNames === 'string'
 						? options.assetFileNames
-						: options.assetFileNames({ type: 'asset', source: '', name: 'name.css' })
+						: options.assetFileNames({ type: 'asset', source: '', name: 'extracted-by-css-entry-points-plugin.css' }),
 				)
 
 				this.emitFile({

--- a/lib/plugins/CSSEntryPoints.ts
+++ b/lib/plugins/CSSEntryPoints.ts
@@ -48,8 +48,8 @@ export function CSSEntryPointsPlugin(options?: CSSEntryPointsPluginOptions) {
 						&& !String(info.source).startsWith('/* extracted by css-entry-points-plugin */')
 						&& !info.name.endsWith('extracted-by-css-entry-points-plugin.css')
 					) {
-						// The new name should have the same path but instead of the .css extension it is .chunk.css
-						return name.replace(/(.css|.\[ext\]|\[extname\])$/, '.chunk.css')
+						// The new name should have the same path but in chunks subdirectory with .chunk.css extension
+						return name.replace(/\/(.+?)(?:.css|.\[ext\]|\[extname\])$/, 'chunks/$1.chunk.css')
 					}
 					return name
 				}
@@ -104,7 +104,7 @@ export function CSSEntryPointsPlugin(options?: CSSEntryPointsPluginOptions) {
 				}
 
 				const source = [...importedCSS.values()]
-					.map((css) => `@import './${basename(css)}';`)
+					.map((css) => `@import './chunks/${basename(css)}';`)
 					.join('\n')
 
 				// Name new CSS entry same as the entry


### PR DESCRIPTION
Maybe it's very personal preferences, but I always find it easer to debug build output when outDirs contains only entries first (files you will need to manually include in apps' templates) and chunks separated.

Before | After
---|---
![image](https://github.com/user-attachments/assets/2c78969b-bce3-462c-946b-3214b69f1891) | ![image](https://github.com/user-attachments/assets/243d0610-ac8b-4271-b5e7-9266d7dc18cf)
