### PR TITLE
v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-## [v1.5.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.4.2...v1.5.0) (2025-01-10)
+## [v1.5.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.0...v1.5.1) (2025-01-22)
+## Fixed
+* fix: Vite 6 made the CSS output file breaking by @susnux in https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/468
 
+## Changed
+* chore(deps): Bump vite-plugin-dts from 4.4.0 to 4.5.0
+* chore(deps-dev): Bump @types/node from 22.10.5 to 22.10.
+
+## [v1.5.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.4.2...v1.5.0) (2025-01-10)
 ### Added
 * Vite 6 support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [v1.5.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.0...v1.5.1) (2025-01-22)
 ## Fixed
-* fix: Vite 6 made the CSS output file breaking by @susnux in https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/468
+* fix: Vite 6 made the CSS output file breaking [\#468](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/468)
 
 ## Changed
-* chore(deps): Bump vite-plugin-dts from 4.4.0 to 4.5.0
-* chore(deps-dev): Bump @types/node from 22.10.5 to 22.10.
+* Updated development dependencies
+* chore(deps): Bump vite-plugin-dts to 4.5.0
 
 ## [v1.5.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.4.2...v1.5.0) (2025-01-10)
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "1.5.0",
+			"version": "1.5.1",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {


### PR DESCRIPTION
## [v1.5.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.0...v1.5.1) (2025-01-22)
## Fixed
* fix: Vite 6 made the CSS output file breaking by @susnux in https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/468

## Changed
* chore(deps): Bump vite-plugin-dts from 4.4.0 to 4.5.0
* chore(deps-dev): Bump @types/node from 22.10.5 to 22.10.
