### PR TITLE
chore: Prepare v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-## [v2.3.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.2.2...v2.3.0)
+## [v2.3.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.0...v2.3.1)
+### Fixed
+* fix: Vite 6 made the CSS output file breaking [\#470](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/470)
 
+### Changed
+* Updated development dependencies
+* chore(deps): Bump vite-plugin-dts to 4.5.0
+
+## [v2.3.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.2.2...v2.3.0)
 ### Added
 * Support for Vite 6
   * Dropped support for Vite 4 as the vue plugin is no longer compatible with v4 and v6.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "2.3.0",
+			"version": "2.3.1",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,22 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {
 		"url": "https://github.com/nextcloud/nextcloud-vite-config/issues"
 	},
 	"license": "AGPL-3.0-or-later",
-	"author": {
-		"name": "Ferdinand Thiessen",
-		"email": "opensource@fthiessen.de"
-	},
+	"author": "Nextcloud GmbH and Nextcloud contributors",
+	"contributors": [
+		"Andy Scherzinger <info@andy-scherzinger.de>",
+		"Ferdinand Thiessen <opensource@fthiessen.de>",
+		"Grigorii K. Shartsev <me@shgk.me>",
+		"John Molakvoæ <skjnldsv@protonmail.com>",
+		"Julius Knorr <jus@bitgrid.net>",
+		"Raimund Schlüßler <raimund.schluessler+github@mailbox.org>",
+		"Richard Steinmetz <richard@steinmetz.cloud>"
+	],
 	"type": "module",
 	"exports": {
 		".": {


### PR DESCRIPTION
## [v2.3.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.0...v2.3.1)
### Fixed
* fix: Vite 6 made the CSS output file breaking [\#470](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/470)

### Changed
* Updated development dependencies
* chore(deps): Bump vite-plugin-dts to 4.5.0