### PR TITLE
[stable1] chore: Prepare v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## [v1.5.2](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.1...v1.5.2) (2025-02-13)
+### Changed
+* chore(deps): Bump vite-plugin-node-polyfills from 0.22.0 to 0.23.0
+  * Required for vite 6 support
+* Updated development dependencies
+
 ## [v1.5.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.0...v1.5.1) (2025-01-22)
-## Fixed
+### Fixed
 * fix: Vite 6 made the CSS output file breaking [\#468](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/468)
 
-## Changed
+### Changed
 * Updated development dependencies
 * chore(deps): Bump vite-plugin-dts to 4.5.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "1.5.1",
+			"version": "1.5.2",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",
@@ -3275,10 +3275,11 @@
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -3525,9 +3526,10 @@
 			"integrity": "sha512-dB68l59BI75W1BUGVTAEJy45CEVuEGy9qPVVQ8pnHyHMn36PLPPoE1mjLH+lo9rKulO3HC2OhbACI/8tCqJBcA=="
 		},
 		"node_modules/elliptic": {
-			"version": "6.5.6",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-			"integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+			"version": "6.6.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+			"integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.11.9",
 				"brorand": "^1.1.0",
@@ -6028,10 +6030,11 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"braces": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {


### PR DESCRIPTION
* chore(deps): Bump vite-plugin-node-polyfills from 0.22.0 to 0.23.0
  * Required for vite 6 support
* Updated development dependencies