### PR TITLE
fix: Do not hide sourcemaps in production build

### DIFF
--- a/__tests__/__snapshots__/appconfig.spec.ts.snap
+++ b/__tests__/__snapshots__/appconfig.spec.ts.snap
@@ -3,5 +3,6 @@
 exports[`app config > replaces process.env 1`] = `
 "/*! third party licenses: js/vendor.LICENSE.txt */
 var e={};window.my_timezone=e.TZ;
+//# sourceMappingURL=@nextcloud-vite-config-main.mjs.map
 "
 `;

--- a/lib/baseConfig.ts
+++ b/lib/baseConfig.ts
@@ -144,7 +144,7 @@ export function createBaseConfig(options: BaseOptions = {}): UserConfigFn {
 			build: {
 				minify: !!options.minify,
 				cssTarget: browserslistToEsbuild(),
-				sourcemap: isDev || 'hidden',
+				sourcemap: true,
 				target: browserslistToEsbuild(),
 			},
 		}),


### PR DESCRIPTION
I do not see a reason why we should hide source maps on production builds and it makes reading traces and debugging a lot harder on production setups.