### PR TITLE
chore: prepare release of v2.3.3

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: CC0-1.0
+
+changelog:
+  categories:
+    - title: 💥 Breaking changes
+      labels:
+        - breaking
+        - "type: breaking"
+    - title: 🚀 Enhancements
+      labels:
+        - enhancement
+        - "type: enhancement"
+    - title: 🐛 Fixed bugs
+      labels:
+        - bug
+        - "type: bug"
+    - title: Other changes
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.3.3](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.3...v2.3.4) (2025-04-28)
+### Changed
+* chore(deps): Bump @vitejs/plugin-vue from 5.2.1 to 5.2.3
+* chore(deps): Bump rollup-plugin-esbuild-minify from 1.2.0 to 1.3.0
+* chore(deps): Bump esbuild and rollup-plugin-esbuild-minify
+
 ## [v2.3.2](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.1...v2.3.2) (2025-03-12)
 ### Fixed
 * fix: Incomplete string escaping or encoding [\#501](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/501) \([susnux](https://github.com/susnux)\)
@@ -7,7 +13,6 @@
 
 ### Changed
 * Updated dependencies
-
 
 ## [v2.3.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.0...v2.3.1)
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "2.3.2",
+			"version": "2.3.3",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {


### PR DESCRIPTION
This release will resolve various GitHub security warning about GHSA `GHSA-67mh-4wv8-2f99` in projects using this shared configuration.