### PR TITLE
chore: prepare v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## [v1.5.4](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.3...v1.5.4) (2025-04-29)
+### Changed
+* chore(deps): Bump rollup-plugin-esbuild-minify from 1.2.0 to 1.3.0
+
 ## [v1.5.3](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.2...v1.5.3) (2025-03-12)
 ### Fixed
 * fix: Do not hide sourcemaps in production build [\#547](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/547)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "1.5.3",
+			"version": "1.5.4",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {


### PR DESCRIPTION
This release will resolve various GitHub security warning about GHSA GHSA-67mh-4wv8-2f99 in projects using this shared configuration.