### PR TITLE
chore: prepare v2.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [v2.3.3](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.3...v2.3.4) (2025-04-28)
+## [v2.3.4](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.3...v2.3.4) (2025-05-07)
+### 🐛 Fixed bugs
+* fix(SPDX): handle vite internal modules and sanitize name [\#606](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/606) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* chore(deps-dev): Bump vite to 6.3.4
+
+## [v2.3.3](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.2...v2.3.3) (2025-04-28)
 ### Changed
 * chore(deps): Bump @vitejs/plugin-vue from 5.2.1 to 5.2.3
 * chore(deps): Bump rollup-plugin-esbuild-minify from 1.2.0 to 1.3.0

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ export default createLibConfig({
 })
 ```
 
-## Notes
+### Notes
 
-### Inlining / injecting CSS
+#### Inlining / injecting CSS
 You can enable inlining CSS code, but please note that this is handled differently for apps and libraries.
 * Apps will inline the CSS by dynamically inject it as `script` tags
 * Libraries will extract the CSS to the dist/assets directory and import it in the entry point
@@ -94,3 +94,27 @@ But this only works in DOM environments, so for libraries this might not work (e
 
 So for libraries the CSS will still be extracted by Vite, but the extracted CSS assets will be imported.
 This way the library user can decide how to handle the imported CSS without relying on a DOM environment.
+
+## Development
+
+### 📤 Releasing a new version
+
+- Pull the latest changes from `main` or `stableX`
+- Checkout a new branch with the tag name (e.g `v4.0.1`): `git checkout -b v<version>`
+- Run `npm version patch --no-git-tag-version` (`npm version minor --no-git-tag-version` if minor).
+  This will return a new version name, make sure it matches what you expect
+- Generate the changelog content from the [release](https://github.com/nextcloud-libraries/nextcloud-vite-config/releases) page.
+  Create a draft release, select the previous tag, click `generate` then paste the content to the `CHANGELOG.md` file
+  1. adjust the links to the merged pull requests and authors so that the changelog also works outside of GitHub
+     by running `npm run prerelease:format-changelog`.
+     This will apply this regex: `by @([^ ]+) in ((https://github.com/)nextcloud-libraries/nextcloud-vite-config/pull/(\d+))`
+     Which this as the replacement: `[\#$4]($2) \([$1]($3$1)\)`
+  2. use the the version as tag AND title (e.g `v4.0.1`)
+  3. add the changelog content as description (https://github.com/nextcloud-libraries/nextcloud-vite-config/releases)
+- Commit, push and create PR
+- Get your PR reviewed and merged
+- Create a milestone with the follow-up version at https://github.com/nextcloud-libraries/nextcloud-vite-config/milestones
+- Move all open tickets and PRs to the follow-up
+- Close the milestone of the version you release
+- Publish the previously drafted release on GitHub
+  ![image](https://user-images.githubusercontent.com/14975046/124442568-2a952500-dd7d-11eb-82a2-402f9170231a.png)

--- a/build/format-changelog.mjs
+++ b/build/format-changelog.mjs
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+console.info('🔎 checking format of CHANGELOG.md')
+
+const file = join(import.meta.dirname, '..', 'CHANGELOG.md')
+const content = await readFile(file, { encoding: 'utf-8' })
+
+const formatted = content
+	.replaceAll(
+		/from \d+\.(\d\.?)+ to (\d\.(\d\.?)+) by @dependabot .+/g,
+		'to $2',
+	)
+	.replaceAll(
+		/by @([^ ]+) in ((https:\/\/github.com\/)nextcloud-libraries\/nextcloud-vite-config\/pull\/(\d+))/g,
+		'[\\#$4]($2) \\([$1]($3$1)\\)',
+	)
+
+if (formatted !== content) {
+	console.info('✏️ fixing format')
+	await writeFile(file, formatted)
+	console.info('🎉 done')
+} else {
+	console.info('✅ no formatting needed - done.')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "2.3.3",
+	"version": "2.3.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "2.3.3",
+			"version": "2.3.4",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "2.3.3",
+	"version": "2.3.4",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {
@@ -35,6 +35,7 @@
 		"build": "tsc",
 		"build:doc": "typedoc --out dist/doc lib/index.ts && touch dist/doc/.nojekyll",
 		"dev": "tsc --watch",
+		"prerelease:format-changelog": "node build/format-changelog.mjs",
 		"lint": "eslint lib",
 		"lint:fix": "eslint --fix lib",
 		"test": "vitest run",


### PR DESCRIPTION
Add release documentation similar to nextcloud-vue and bump version.

---

## [v2.3.4](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.3.3...v2.3.4) (2025-05-07)
### 🐛 Fixed bugs
* fix(SPDX): handle vite internal modules and sanitize name [\#606](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/606) \([susnux](https://github.com/susnux)\)

### Changed
* chore(deps-dev): Bump vite to 6.3.4