### PR TITLE
chore: adjust defaults to use SPDX over 3rdparty BOM

### DIFF
--- a/__tests__/__snapshots__/appconfig.spec.ts.snap
+++ b/__tests__/__snapshots__/appconfig.spec.ts.snap
@@ -1,8 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`app config > replaces process.env 1`] = `
-"/*! third party licenses: js/vendor.LICENSE.txt */
-var e={};window.my_timezone=e.TZ;
+"var e={};window.my_timezone=e.TZ;
 //# sourceMappingURL=@nextcloud-vite-config-main.mjs.map
 "
 `;

--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -68,17 +68,18 @@ export interface AppOptions extends Omit<BaseOptions, 'inlineCSS'> {
 
 	/**
 	 * Location of license summary file of third party dependencies
-	 * Pass `false` to disable generating a license file.
 	 *
-	 * @default 'js/vendor.LICENSE.txt'
+	 * @default undefined (no BOM generated)
 	 */
-	thirdPartyLicense?: false | string
+	thirdPartyLicense?: string
 
 	/**
 	 * Extract license information from built assets into `.license` files
-	 * This is needed to be REUSE complient
+	 * This is needed to be REUSE complient.
+	 *
+	 * @default {}
 	 */
-	extractLicenseInformation?: true | REUSELicensesPluginOptions
+	extractLicenseInformation?: REUSELicensesPluginOptions | false
 }
 
 /**
@@ -100,7 +101,6 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 		nodePolyfills: {
 			protocolImports: true,
 		},
-		thirdPartyLicense: options.thirdPartyLicense === undefined ? 'js/vendor.LICENSE.txt' : options.thirdPartyLicense,
 		...options,
 	}
 
@@ -153,7 +153,7 @@ export const createAppConfig = (entries: { [entryAlias: string]: string }, optio
 				plugins.push(CSSEntryPointsPlugin({ createEmptyEntryPoints: options.createEmptyCSSEntryPoints }))
 			}
 
-			if (options.extractLicenseInformation && env.mode !== 'development') {
+			if (options.extractLicenseInformation !== false && env.mode !== 'development') {
 				plugins.push(REUSELicensesPlugin(
 					typeof options.extractLicenseInformation === 'object'
 						? options.extractLicenseInformation

--- a/lib/baseConfig.ts
+++ b/lib/baseConfig.ts
@@ -47,11 +47,10 @@ export interface BaseOptions {
 	coreJS?: CoreJSPluginOptions
 	/**
 	 * Location of license summary file of third party dependencies
-	 * Pass `false` to disable generating a license file.
 	 *
-	 * @default 'dist/vendor.LICENSE.txt'
+	 * @default false
 	 */
-	thirdPartyLicense?: false | string
+	thirdPartyLicense?: string
 	/**
 	 * Customize the asset file names.
 	 * Similar to `output.assetFileNames` in rollup config,
@@ -105,13 +104,13 @@ export function createBaseConfig(options: BaseOptions = {}): UserConfigFn {
 		}
 
 		// Add license header with all dependencies
-		if (options.thirdPartyLicense !== false) {
+		if (options.thirdPartyLicense) {
 			const licenseTemplate = readFileSync(new URL('../banner-template.txt', import.meta.url), 'utf-8')
 
 			plugins.push(license({
 				thirdParty: {
 					output: {
-						file: options.thirdPartyLicense || 'dist/vendor.LICENSE.txt',
+						file: options.thirdPartyLicense,
 						template: licenseTemplate,
 					},
 				},


### PR DESCRIPTION
This is the way we expect apps to be built, using SPDX headers and license files.
So this is somewhat a breaking change but we just adjust the defaults to match with how apps should be working by default.