### PR TITLE
fix: use correct path for watch parameter

### DIFF
--- a/lib/baseConfig.ts
+++ b/lib/baseConfig.ts
@@ -146,10 +146,8 @@ export function createBaseConfig(options: BaseOptions = {}): UserConfigFn {
 				sourcemap: true,
 				target: browserslistToEsbuild(),
 				// fix watch mode if the output is within the input (base directory)
-				rollupOptions: {
-					watch: {
-						allowInputInsideOutputPath: true,
-					},
+				watch: {
+					allowInputInsideOutputPath: true,
 				},
 			},
 		}),


### PR DESCRIPTION
This replaces a PR for Forms (https://github.com/nextcloud/forms/pull/2872) that fixes https://github.com/nextcloud/forms/issues/2869

In #666 the rollup config was adjusted but used a wrong path for the introduced parameter.