### PR TITLE
chore: prepare v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.7.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.6...v1.6.0) (2025-09-02)
+### Added
+* Minimum Vite version is now v7.1.4
+
+### Changed
+* fix: bump vite version to fix running in watch mode [\#694](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/694)
+
 ## [v1.6.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.6...v1.6.0) (2025-07-23)
 ### Added
 * Vite 7 support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "1.6.0",
+			"version": "1.7.0",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {


### PR DESCRIPTION
- [ ] https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/695

---

## [v1.7.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.6...v1.6.0) (2025-09-02)
### Added
* Minimum Vite version is now v7.1.4

### Changed
* fix: bump vite version to fix running in watch mode [\#694](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/694)