### PR TITLE
chore: prepare v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.7.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.7.0...v1.7.1) (2025-09-29)
+### Fixed
+* fix: make configuration rolldown compatible [\#718](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/718)
+
+### Changed
+* chore(deps): Bump rollup-plugin-node-externals to 8.1.1
+* chore(deps): Bump magic-string to 0.30.19
+
 ## [v1.7.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.5.6...v1.6.0) (2025-09-02)
 ### Added
 * Minimum Vite version is now v7.1.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "1.7.0",
+			"version": "1.7.1",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {


### PR DESCRIPTION
### Fixed
* fix: make configuration rolldown compatible [\#718](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/718)

### Changed
* chore(deps): Bump rollup-plugin-node-externals to 8.1.1
* chore(deps): Bump magic-string to 0.30.19