### PR TITLE
chore: prepare v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v2.5.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.5.0...v2.5.1) (2025-09-29)
+### 🐛 Fixed bugs
+* fix: make configuration rolldown compatible [\#717](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/717) \([susnux](https://github.com/susnux)\)
+
+### Other changes
+* chore(deps): Bump rollup-plugin-node-externals to 8.1.1
+* chore(deps): Bump magic-string to 0.30.19
+
 ## [v2.5.0](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.4.0...v2.5.0) (2025-09-02)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "2.5.0",
+			"version": "2.5.1",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud/nextcloud-vite-config",
 	"bugs": {


### PR DESCRIPTION
### 🐛 Fixed bugs
* fix: make configuration rolldown compatible [\#717](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/717) \([susnux](https://github.com/susnux)\)

### Other changes
* chore(deps): Bump rollup-plugin-node-externals to 8.1.1
* chore(deps): Bump magic-string to 0.30.19