### PR TITLE
chore: prepare v3.0.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,33 @@ For this please track the upstream issue:
   If you really need a bill-of-materials you can use the now native Vite option `build.license`.
 * This configuration version is now compatible with apps targeting Vue 3 and Vue 2.
   For Vue 2 you will have to adjust your dependencies a bit, [more information can be found in the README](./README.md#use-with-vue-2).
+* Node 22.12+ is the now the minimum supported Node version
+
+### Other changes
+* The configuration officially supports the upcoming LTS Node 26
+* Vite 8.1+ is now a peer dependency
+* `vite-plugin-dts` has been replaced with `rolldown-plugin-dts`
+* Updated dependencies:
+  * Bump `vite-plugin-css-injected-by-js` to 5.0.1
+
+## [v2.5.3](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.5.2...v2.5.3) (2026-06-30)
+## What's Changed
+### 🐛 Fixed bugs
+* fix(lib): remove extra `formats` option [\#771](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/771)
+* fix(lib): remove hash from the file names [\#772](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/772)
+
+### Other changes
+* chore: update Node and NPM dev versions to align with apps [\#757](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/757)
+* chore: migrate code linting to ESLint v10 and eslint config v9 [\#855](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/855)
+* Updated dependencies:
+  * Bump `rollup-plugin-corejs` to 1.0.2
+  * Bump `@rollup/plugin-replace` to 6.0.3
+  * Bump `@vitejs/plugin-vue` to 6.0.4
+  * Bump `vite-plugin-css-injected-by-js`
+  * Bump `rollup-plugin-license` to 3.7.1
+  * Bump `rollup-plugin-node-externals` to 9.0.1
+  * Bump `vite-plugin-node-polyfills` to 0.28.0
+* ci: update all workflow templates from organization template repository
 
 ## [v2.5.2](https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v2.5.1...v2.5.2) (2025-10-20)
 ### 🐛 Fixed bugs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "3.0.0-dev.0",
+	"version": "3.0.0-beta.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vite-config",
-			"version": "3.0.0-dev.0",
+			"version": "3.0.0-beta.0",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"browserslist-to-esbuild": "^2.1.1",
@@ -1158,8 +1158,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@rollup/plugin-inject": {
 			"version": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vite-config",
-	"version": "3.0.0-dev.0",
+	"version": "3.0.0-beta.0",
 	"description": "Shared Vite configuration for Nextcloud apps and libraries",
 	"homepage": "https://github.com/nextcloud-libraries/nextcloud-vite-config",
 	"bugs": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
 	"bugs": {
 		"url": "https://github.com/nextcloud-libraries/nextcloud-vite-config/issues"
 	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/nextcloud-libraries/nextcloud-vite-config.git"
+	},
 	"license": "AGPL-3.0-or-later",
 	"author": "Nextcloud GmbH and Nextcloud contributors",
 	"contributors": [


### PR DESCRIPTION
## v3.0.0-beta.0
### ⚠️ Warning
For the moment we strongly recommend to only use Vite v8 for bundling libraries.
Bundling apps can lead to increase number of chunks due to some issues with the new rolldown backend.
For this please track the upstream issue:
- https://github.com/rolldown/rolldown/issues/9463
### Breaking changes
* This configuration is now only working with Vite v8 (rolldown / OXC based).
* The `thirdPartyLicense` config option has been removed.
  We recommend using SPDX headers, which is already the default for apps with the `extractLicenseInformation` option.
  If you really need a bill-of-materials you can use the now native Vite option `build.license`.
* This configuration version is now compatible with apps targeting Vue 3 and Vue 2.
  For Vue 2 you will have to adjust your dependencies a bit, [more information can be found in the README](./README.md#use-with-vue-2).
* Node 22.12+ is the now the minimum supported Node version

### Other changes
* The configuration officially supports the upcoming LTS Node 26
* Vite 8.1+ is now a peer dependency
* `vite-plugin-dts` has been replaced with `rolldown-plugin-dts`
* Updated dependencies:
  * Bump `vite-plugin-css-injected-by-js` to 5.0.1