### PR TITLE
feat(lib): allow to override DTS plugin options

### DIFF
--- a/lib/libConfig.ts
+++ b/lib/libConfig.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { Options as DtsPluginOptions } from 'rolldown-plugin-dts'
 import type { ExternalsOptions } from 'rollup-plugin-node-externals'
 import type { LibraryFormats, Plugin, Rolldown, UserConfig, UserConfigFn } from 'vite'
 import type { BaseOptions } from './baseConfig.js'
@@ -35,13 +36,15 @@ export interface LibraryOptions extends BaseOptions {
 	/**
 	 * Options for the Vite DTS plugin
 	 *
-	 * This plugin allows to create .d.ts files for your library including the .vue files
-	 * Pass `false` to disable the plugin
+	 * This plugin allows to create .d.ts files for your library including the .vue files.
+	 * Pass `false` to disable the plugin and not generate any .d.ts files.
+	 * If you do not use Vue in your project set `{ vue: false }` to disable the Vue support and speed up the build.
+	 * Otherwise you can also directly set any of the options of the `rolldown-plugin-dts` plugin.
 	 */
 	DtsPluginOptions?: false | {
 		/** If set to false no Vue types will be generated */
 		vue?: boolean
-	}
+	} & DtsPluginOptions
 
 	/**
 	 * Formats you like your library to be built
@@ -107,6 +110,7 @@ export function createLibConfig(entries: { [entryAlias: string]: string }, optio
 					vue: options.DtsPluginOptions?.vue ?? true,
 					parallel: options.DtsPluginOptions?.vue ?? true,
 					oxc: options.DtsPluginOptions?.vue === false, // Oxc is faster but does not support .vue files
+					...options.DtsPluginOptions,
 				})) as Plugin[])
 			}
 


### PR DESCRIPTION
On most projects this is needed, because the majority of libraries is not yet ready for `isolatedDeclarations` which is required by OXC.

So for those libraries the DTS plugin only works when setting `{ oxc: false, tsgo: true }` and installing `@typescript/native-preview`.

Otherwise those libraries would have to enable `isolatedDeclarations` in their tsconfig and adjust their code to comply.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
