### PR TITLE
fix: improve chunking behavior when using the app config

### DIFF
--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -245,12 +245,17 @@ export function createAppConfig(entries: { [entryAlias: string]: string }, optio
 							},
 							comments: !(options.minify ?? env.mode === 'production'),
 							strictExecutionOrder: true,
-							codeSplitting: options.codeSplitting ?? {
-								groups: [
-									...(options?.coreJS ? [{ name: 'polyfill', test: /core-js/ }] : []),
-									...(Object.keys(entries).length > 1 ? [{ name: 'vendor', test: /(^\0|[\\/]node_modules[\\/])/, entriesAware: true, entriesAwareMergeThreshold: 20_000 }] : []),
-								],
-							},
+							codeSplitting: options.codeSplitting ?? (Object.keys(entries).length === 1
+								? false // no code splitting for single entry point by default
+								: {
+										// No `maxSize` here because of rolldown bug: https://github.com/rolldown/rolldown/issues/10718
+										// `maxSize` chunking is applied before tree shaking -> adds unnecessary chunks and increases the size of the final build
+										groups: [
+											{ name: 'shared', minShareCount: 2, minSize: 70_000 },
+											{ name: 'common', entriesAware: true, entriesAwareMergeThreshold: 90_000, minSize: 70_000 },
+											{ name: 'remain' },
+										],
+									}),
 						},
 					},
 				},


### PR DESCRIPTION
ref: https://github.com/rolldown/rolldown/issues/10718

Tested with circles app:
- Vite 7: 20 chunks, total 2088390 bytes
- Vite 8 before: 28 chunks, total 3046359 bytes
- Vite 8 now: 12 chunks, totoal 2127745 bytes

There is still a bug to not consider Vite 8 ready, it seems rolldown has a problem with `maxSize` so if this is set the chunks are splitted before treeShaking causing chunks to include things not really needed (e.g. nextcloud-vue barrel modules) and then cannot be tree shaken because its used in another chunk...
So the problem: without `maxSize` single chunks can grow pretty big.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
