### PR TITLE
fix(appconfig): use hash to identify chunks

### DIFF
--- a/lib/appConfig.ts
+++ b/lib/appConfig.ts
@@ -229,6 +229,9 @@ export function createAppConfig(entries: { [entryAlias: string]: string }, optio
 								} else if (/css/i.test(extType)) {
 									if (userConfig.build?.cssCodeSplit !== false) {
 										// we need hashed css name for css chunks as a cache buster
+										if (env.mode === 'production') {
+											return 'css/[hash].css'
+										}
 										return 'css/[name]-[hash].css'
 									}
 									return `css/${assetsPrefix}[name].css`
@@ -241,6 +244,10 @@ export function createAppConfig(entries: { [entryAlias: string]: string }, optio
 								return `js/${assetsPrefix}[name].mjs`
 							},
 							chunkFileNames: () => {
+								if (env.mode === 'production') {
+									// shorter names in production reduce also imports and so filesize
+									return 'js/[hash].chunk.mjs'
+								}
 								return 'js/[name]-[hash].chunk.mjs'
 							},
 							comments: !(options.minify ?? env.mode === 'production'),


### PR DESCRIPTION
Chunk names are not helpful or needed in production. During development the naming can help, but on production a longer name means also a bit more space needed.

This does not change that much but as we also mangle variable names we can also mangle file names to save a bit.

Moreover on the web often shorter URLs are better and this also removes usage like `~` within URLs.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
